### PR TITLE
Avoid errors on make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,5 @@ uninstall:
 	rm -rf ~/.local/share/gnome-shell/extensions/tuxedo-keyboard-gnome-extension
 
 clean:
-	rm src/schemas/gschemas.compiled
-	rm tuxedo-keyboard-gnome-extension.zip
+	rm src/schemas/gschemas.compiled || true
+	rm tuxedo-keyboard-gnome-extension.zip || true


### PR DESCRIPTION
During first installation, `make clean` is trying to remove folders that are still not created so it fails.

This PR skip the `rm` command in such cases.