### PR TITLE
Avoid fails in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,5 @@ uninstall:
 	rm -rf ~/.local/share/gnome-shell/extensions/tuxedo-keyboard-gnome-extension
 
 clean:
-	rm src/schemas/gschemas.compiled
-	rm tuxedo-keyboard-gnome-extension.zip
+	rm src/schemas/gschemas.compiled || true
+	rm tuxedo-keyboard-gnome-extension.zip || true


### PR DESCRIPTION
Current Makefile causes a fail when the `clean` process runs and the elements to be removed do not exist.

This PR avoid this fail by adding the `|| true` pattern to both lines.